### PR TITLE
Single tenancy and encryption

### DIFF
--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -863,6 +863,9 @@ def create(vm_=None, call=None):
     if az_ is not None:
         params['Placement.AvailabilityZone'] = az_
 
+    if 'dedicated' in vm_ and vm_['dedicated']:
+        params['Placement.Tenancy'] = 'dedicated'
+
     subnetid_ = get_subnetid(vm_)
     if subnetid_ is not None:
         params['SubnetId'] = subnetid_

--- a/saltcloud/clouds/ec2.py
+++ b/saltcloud/clouds/ec2.py
@@ -1209,6 +1209,8 @@ def create_attach_volumes(name, kwargs, call=None):
             volume_dict['type'] = volume['type']
         if 'iops' in volume:
             volume_dict['iops'] = volume['iops']
+        if 'encrypted' in volume:
+            volume_dict['encrypted'] = volume['encrypted']
 
         if 'volume_id' not in volume_dict:
             created_volume = create_volume(volume_dict, call='function')
@@ -2032,6 +2034,9 @@ def create_volume(kwargs=None, call=None):
 
     if 'iops' in kwargs and kwargs.get('type', 'standard') == 'io1':
         params['Iops'] = kwargs['iops']
+
+    if 'encrypted' in kwargs and kwargs['encrypted']:
+        params['Encrypted'] = True
 
     log.debug(params)
 


### PR DESCRIPTION
Allows you to make a profile like so:

```
linux_raid_xlarge_300G_vpc_hipaa:
  dedicated: True
  volumes:
    - { size: 50, device: /dev/sdf, type: gp2, encrypted: True }
    - { size: 50, device: /dev/sdg, type: gp2, encrypted: True }
    - { size: 50, device: /dev/sdh, type: gp2, encrypted: True }
    - { size: 50, device: /dev/sdi, type: gp2, encrypted: True }
    - { size: 50, device: /dev/sdj, type: gp2, encrypted: True }
    - { size: 50, device: /dev/sdk, type: gp2, encrypted: True }
    - { device: /dev/sdb, virtualname: ephemeral0 }
  extends: linux_raid_xlarge_300G_vpc
```
